### PR TITLE
Fix opening animation for mobile view

### DIFF
--- a/src/components/Opening.vue
+++ b/src/components/Opening.vue
@@ -1,46 +1,54 @@
 <template>
-  <div class="opening-wrapper" id="openingWrapper">
-    <div class="opening opening--a">
-      <v-row
-        align="center"
-        class="opening__row"
-        justify="center"
-        style="background-image: url(/static/coding.jpg)"
-      >
-        <h4 class="text-h3 opening__text">Development</h4>
-      </v-row>
-    </div>
+  <transition
+    @after-enter="showOpening = false"
+    leave-active-class="opening-wrapper--end-active"
+    leave-class="opening-wrapper--end"
+    leave-to-class="opening-wrapper--end-to"
+    name="opening-wrapper"
+  >
+    <div class="opening-wrapper" v-show="showOpening" ref="openingWrapper">
+      <div class="opening opening--a">
+        <v-row
+          align="center"
+          class="opening__row"
+          justify="center"
+          style="background-image: url(/static/coding.jpg)"
+        >
+          <h4 class="text-h4 opening__text">Development</h4>
+        </v-row>
+      </div>
 
-    <div class="opening opening--b">
-      <v-row
-        align="center"
-        class="opening__row"
-        justify="center"
-        style="background-image: url(/static/design.jpg)"
-      >
-        <h4 class="text-h3 opening__text">Design</h4>
-      </v-row>
-    </div>
+      <div class="opening opening--b">
+        <v-row
+          align="center"
+          class="opening__row"
+          justify="center"
+          style="background-image: url(/static/design.jpg)"
+        >
+          <h4 class="text-h4 opening__text">Design</h4>
+        </v-row>
+      </div>
 
-    <div class="opening opening--c">
-      <v-row
-        align="center"
-        class="opening__row"
-        justify="center"
-        style="background-image: url(/static/digital-media.jpg)"
-      >
-        <h4 class="text-h3 opening__text">Digital Media</h4>
-      </v-row>
-    </div>
+      <div class="opening opening--c">
+        <v-row
+          align="center"
+          class="opening__row"
+          justify="center"
+          style="background-image: url(/static/digital-media.jpg)"
+        >
+          <h4 class="text-h4 opening__text">Digital Media</h4>
+        </v-row>
+      </div>
 
-    <v-btn
-      class="opening-wrapper__button ma-4"
-      color="#36e8c7"
-      rounded
-      v-on:click="skipAnimation()"
-      >skip</v-btn
-    >
-  </div>
+      <v-btn
+        class="opening-wrapper__button ma-4"
+        color="#36e8c7"
+        rounded
+        @click="skipAnimation()"
+        >skip</v-btn
+      >
+    </div>
+  </transition>
 </template>
 
 <script lang="ts">
@@ -50,23 +58,28 @@ export default Vue.extend({
   name: 'Opening',
   computed: {},
   components: {},
-  data: () => ({}),
+  data: () => ({
+    animationCount: 0,
+    showOpening: true,
+  }),
   methods: {
-    onWrapperSkipEnd(event: TransitionEvent) {
-      const target = event.target as HTMLElement;
-
-      if (target.id === 'openingWrapper') {
-        target.style.display = 'none';
-      }
-    },
     skipAnimation() {
-      const wrapper = document.getElementById('openingWrapper');
+      this.showOpening = false;
+    },
+    checkAnimation() {
+      this.animationCount += 1;
 
-      if (wrapper) {
-        wrapper.classList.add('opening-wrapper--skipping');
-        wrapper.addEventListener('transitionend', this.onWrapperSkipEnd);
+      if (this.animationCount === 3) {
+        this.showOpening = false;
       }
     },
+  },
+  mounted() {
+    this.$nextTick(() => {
+      const wrapper = this.$refs.openingWrapper as HTMLElement;
+
+      wrapper.addEventListener('animationend', this.checkAnimation);
+    });
   },
 });
 </script>
@@ -89,8 +102,12 @@ $yellow: #f5f05e;
   transition: opacity 0.5s ease;
   z-index: 200;
 
-  &--skipping {
-    opacity: 0;
+  &--end {
+    opacity: 1;
+
+    &-active {
+      opacity: 0;
+    }
   }
 
   &__button {
@@ -104,7 +121,9 @@ $yellow: #f5f05e;
 
 .opening {
   bottom: 0;
+  left: 0;
   position: absolute;
+  right: 0;
   top: 0;
 
   &__row {
@@ -112,88 +131,96 @@ $yellow: #f5f05e;
     background-size: cover;
     height: 100%;
   }
+
+  .text-h4 {
+    font-size: 28px !important;
+    font-weight: 300 !important;
+
+    @media screen and (min-width: map-deep-get($grid-breakpoints, 'sm')) {
+      font-size: 36px !important;
+      font-weight: 400 !important;
+    }
+
+    @media screen and (min-width: map-deep-get($grid-breakpoints, 'md')) {
+      font-size: 48px !important;
+    }
+  }
 }
 
 .opening--a {
-  animation: openingAnimation1 5s ease 1 normal;
+  animation: openingAnimation1 3s ease 1 normal forwards;
   background-color: $yellow;
-  left: 0;
-  right: 66.66%;
   z-index: 2;
+  font-size: 14px;
 
   & .opening__text {
     color: $yellow;
     text-shadow: #ffffff 0 0 4px;
   }
+
+  @media screen and (min-width: map-deep-get($grid-breakpoints, 'md')) {
+    top: 0;
+  }
 }
 
 .opening--b {
-  animation: openingAnimation2 7.5s ease 3.75s 1 normal;
+  animation: openingAnimation2 4s ease 2s 1 normal forwards;
   background-color: $teal;
-  left: 33.33%;
-  right: 33.33%;
+  top: 33.33%;
   z-index: 1;
 
   & .opening__text {
     color: $teal;
     text-shadow: #000000 0 0 10px;
   }
+
+  @media screen and (min-width: map-deep-get($grid-breakpoints, 'md')) {
+    left: 33.33%;
+    top: 0;
+  }
 }
 
 .opening--c {
-  animation: openingAnimation3 10s ease 5s 1 normal;
+  animation: openingAnimation3 6s ease 4s 1 normal forwards;
   background-color: $lavender;
-  left: 66.66%;
-  right: 0;
+  top: 66.66%;
   z-index: 0;
 
   & .opening__text {
     color: $lavender;
     text-shadow: #000000 0 0 10px;
   }
+
+  @media screen and (min-width: map-deep-get($grid-breakpoints, 'md')) {
+    left: 66.66%;
+    top: 0;
+  }
 }
 
 @keyframes openingAnimation1 {
   0% {
     background-color: #000000;
-    right: 0;
   }
   75% {
     background-color: $yellow;
-    right: 0;
+    bottom: 0;
   }
   100% {
-    right: 66.66%;
-  }
-}
-
-@media screen and (min-width: map-deep-get($grid-breakpoints, 'sm')) {
-  @keyframes openingAnimation1 {
-    0% {
-      background-color: #000000;
-      right: 0;
-    }
-    75% {
-      background-color: $yellow;
-      right: 0;
-    }
-    100% {
-      right: 66.66%;
-    }
+    bottom: 66.66%;
   }
 }
 
 @keyframes openingAnimation2 {
   0% {
     background-color: #000000;
-    right: 0;
+    bottom: 0;
   }
   75% {
     background-color: $teal;
-    right: 0;
+    bottom: 0;
   }
   100% {
-    right: 33.33%;
+    bottom: 33.33%;
   }
 }
 
@@ -207,7 +234,47 @@ $yellow: #f5f05e;
   75% {
     background-color: $lavender;
   }
-  100% {
+}
+
+@media screen and (min-width: map-deep-get($grid-breakpoints, 'md')) {
+  @keyframes openingAnimation1 {
+    0% {
+      background-color: #000000;
+      right: 0;
+    }
+    75% {
+      background-color: $yellow;
+      right: 0;
+    }
+    100% {
+      right: 66.66%;
+    }
+  }
+
+  @keyframes openingAnimation2 {
+    0% {
+      background-color: #000000;
+      right: 0;
+    }
+    75% {
+      background-color: $teal;
+      right: 0;
+    }
+    100% {
+      right: 33.33%;
+    }
+  }
+
+  @keyframes openingAnimation3 {
+    0% {
+      background-color: #000000;
+    }
+    50% {
+      background-color: #000000;
+    }
+    75% {
+      background-color: $lavender;
+    }
   }
 }
 </style>


### PR DESCRIPTION
Adds a mobile layout to the opening animation.
Uses `<transition>` Vue component to hide `openingWrapper` on skip or end of animations.

Closes #5 